### PR TITLE
Allow base templates to be removed

### DIFF
--- a/Sinj/Properties/AssemblyInfo.cs
+++ b/Sinj/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.11.0")]
-[assembly: AssemblyFileVersion("1.0.11.0")]
+[assembly: AssemblyVersion("1.0.12.0")]
+[assembly: AssemblyFileVersion("1.0.12.0")]

--- a/Sinj/PushHandler.cs
+++ b/Sinj/PushHandler.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.Windows;
 using System.Web;
+using System.Configuration;
 
 namespace Sinj
 {
@@ -57,13 +58,16 @@ namespace Sinj
 				{
 					try
 					{
-						using (new Sitecore.SecurityModel.SecurityDisabler())
+						using (new Sitecore.Security.Accounts.UserSwitcher(Sitecore.Security.Accounts.User.FromName(RunAsUser, true)))
 						{
-							foreach (string script in scripts)
+							using (new Sitecore.SecurityModel.SecurityDisabler())
 							{
-								pathIndex++;
+								foreach (string script in scripts)
+								{
+									pathIndex++;
 
-								engine.Execute(script);
+									engine.Execute(script);
+								}
 							}
 						}
 
@@ -83,10 +87,26 @@ namespace Sinj
 				}
 			}
 		}
-
+		
 		private static string GetDebugString(string[] array)
 		{
 			return array == null ? "null" : array.Length.ToString();
+		}
+
+
+		private string RunAsUser
+		{
+			get
+			{
+				var configValue = ConfigurationManager.AppSettings["Sinj.RunAsUser"];
+
+				if (string.IsNullOrWhiteSpace(configValue))
+				{
+					return "sitecore\\admin";
+				}
+
+				return configValue;
+			}
 		}
 	}
 }


### PR DESCRIPTION
We were only using the SecurityDisabler to allow Sinj to update without
a user context. This worked fine for most things, but when removing a
base template from a template this wasn't being taken into account and
an exception was being thrown that crashed the app pool.

Raised with Sitecore support (470391) who suggested this fix.

Default to the sitecore admin user but this can be overridden using an
app setting named "Sinj.RunAsUser".
