### PR TITLE
Allow a user to be specified in scripts where needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.user
 *.suo
 Library/Sitecore.Kernel.dll
+.vs/

--- a/Scripts/sc-items.js
+++ b/Scripts/sc-items.js
@@ -321,7 +321,18 @@ var scDeleteItemById = function (itemId) {
     }
 };
 
+var scCheckForFieldUpdatesRequiringPrivilege = function (fieldName) {
+	// Need to run within the context of an admin user to make certain changes to base templates (see sitecore issue 470391). Check if running in the context of a user and throw error otherwise.
+	if (fieldName.toLowerCase() == 'base template' || fieldName.toLowerCase() == '__base template') {
+		if (!$sc.hasUserContext) {
+			throw new Error("Sitecore requires a user context to succesfully complete some Base Template operations. Specify a user to run as in your script using '$sc.runAsUser(username)'. The specified user must be able to update Base Templates (e.g. \"sitecore\\\\admin\"). The user context will end when the end of the current script is reached, or you call '$sc.endRunAsUser`, whichever comes first.");
+		}
+	}
+};
+
 function scUpdateSingleField(id, language, fieldName, value) {
+	scCheckForFieldUpdatesRequiringPrivilege(fieldName);
+
     var updatePackage =
     {
         item: scItemQuery(id),

--- a/Scripts/sc-items.js
+++ b/Scripts/sc-items.js
@@ -325,7 +325,7 @@ var scCheckForFieldUpdatesRequiringPrivilege = function (fieldName) {
 	// Need to run within the context of an admin user to make certain changes to base templates (see sitecore issue 470391). Check if running in the context of a user and throw error otherwise.
 	if (fieldName.toLowerCase() == 'base template' || fieldName.toLowerCase() == '__base template') {
 		if (!$sc.hasUserContext) {
-			throw new Error("Sitecore requires a user context to succesfully complete some Base Template operations. Specify a user to run as in your script using '$sc.runAsUser(username)'. The specified user must be able to update Base Templates (e.g. \"sitecore\\\\admin\"). The user context will end when the end of the current script is reached, or you call '$sc.endRunAsUser`, whichever comes first.");
+			throw new Error("Sitecore requires a user context to succesfully complete some Base Template operations. Specify a user to run as in your script using '$sc.runAsUser(username)'. The specified user must be able to update Base Templates (e.g. \"sitecore\\\\admin\"). The user context will end when the end of the current script is reached, or you call '$sc.runAsUser('')`, whichever comes first.");
 		}
 	}
 };

--- a/Scripts/sc-templates.js
+++ b/Scripts/sc-templates.js
@@ -43,6 +43,12 @@ var scInsertTemplate = function (packet) {
 		}
 	}
 
+	if (item != null) {
+		for (var name in packet.fields) {
+			scCheckForFieldUpdatesRequiringPrivilege(name);
+		}
+	}
+
 	if (item == null) {
 		if (parentBranch == null) {
 			var parentTemplate = $sc.db.Templates.Item.get($scTemplateIDs.Template);

--- a/Sinj.CommandLine/Properties/AssemblyInfo.cs
+++ b/Sinj.CommandLine/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.16.0")]
-[assembly: AssemblyFileVersion("1.0.16.0")]
+[assembly: AssemblyVersion("1.0.17.0")]
+[assembly: AssemblyFileVersion("1.0.17.0")]

--- a/Sinj/PushContext.cs
+++ b/Sinj/PushContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.ClearScript;
+using Sitecore.Security.Accounts;
 using Sitecore.SecurityModel;
 using System;
 using System.Collections.Generic;
@@ -47,6 +48,42 @@ namespace Sinj
 			response.Write(String.Format("{1:D4} - {0}\r\n", message, (int)duration.TotalSeconds));
 
 			response.Flush();
+		}
+
+		[ScriptMember(Name = "runAsUser")]
+		public void RunAsUser(string username)
+		{
+			if (string.IsNullOrWhiteSpace(username))
+			{
+				return;
+			}
+
+			if (UserSwitcher.CurrentValue != null)
+			{
+				UserSwitcher.Exit();
+			}
+
+			Log(string.Format("Running as '{0}'", username));
+			UserSwitcher.Enter(User.FromName(username, true));
+		}
+
+		[ScriptMember(Name = "endRunAsUser")]
+		public void EndRunAsUser()
+		{
+			if (UserSwitcher.CurrentValue != null)
+			{
+				Log(string.Format("Finished running as '{0}'", UserSwitcher.CurrentValue.Name));
+				UserSwitcher.Exit();
+			}
+		}
+
+		[ScriptMember(Name = "hasUserContext")]
+		public bool HasUserContext
+		{
+			get
+			{
+				return UserSwitcher.CurrentValue != null;
+			}
 		}
 	}
 }

--- a/Sinj/PushContext.cs
+++ b/Sinj/PushContext.cs
@@ -53,28 +53,19 @@ namespace Sinj
 		[ScriptMember(Name = "runAsUser")]
 		public void RunAsUser(string username)
 		{
-			if (string.IsNullOrWhiteSpace(username))
-			{
-				return;
-			}
-
-			if (UserSwitcher.CurrentValue != null)
-			{
-				UserSwitcher.Exit();
-			}
-
-			Log(string.Format("Running as '{0}'", username));
-			UserSwitcher.Enter(User.FromName(username, true));
-		}
-
-		[ScriptMember(Name = "endRunAsUser")]
-		public void EndRunAsUser()
-		{
 			if (UserSwitcher.CurrentValue != null)
 			{
 				Log(string.Format("Finished running as '{0}'", UserSwitcher.CurrentValue.Name));
 				UserSwitcher.Exit();
 			}
+
+			if (string.IsNullOrWhiteSpace(username))
+			{
+				return;
+			}
+
+			Log(string.Format("Running as '{0}'", username));
+			UserSwitcher.Enter(User.FromName(username, true));
 		}
 
 		[ScriptMember(Name = "hasUserContext")]

--- a/Sinj/PushHandler.cs
+++ b/Sinj/PushHandler.cs
@@ -42,10 +42,11 @@ namespace Sinj
 
 			using (ScriptEngine engine = new JScriptEngine(flags))
 			{
-                		engine.AddHostObject("$sc", new PushContext());
+				var pushContext = new PushContext();
+                engine.AddHostObject("$sc", pushContext);
                 		
-                		//these global variables should not be here polluting the global namespace in javascript
-                		//they should hang off $sc, that's what PushContext is for - KW
+                //these global variables should not be here polluting the global namespace in javascript
+                //they should hang off $sc, that's what PushContext is for - KW
 				engine.AddHostType("$scItemManager", typeof(Sitecore.Data.Managers.ItemManager));
 				engine.AddHostType("$scTemplateManager", typeof(Sitecore.Data.Managers.TemplateManager));
 				engine.AddHostType("$scLanguage", typeof(Sitecore.Globalization.Language));
@@ -54,23 +55,22 @@ namespace Sinj
 				engine.AddHostType("$scTemplateIDs", typeof(Sitecore.TemplateIDs));
 				engine.AddHostType("$scTemplateFieldIDs", typeof(Sitecore.TemplateFieldIDs));
 				engine.AddHostType("$scTemplateFieldSharing", typeof(Sitecore.Data.Templates.TemplateFieldSharing));
-                		engine.AddHostObject("$scMediaItem", new MediaItem());
-                		engine.AddHostType("$scFieldIDs", typeof(Sitecore.FieldIDs));
+                engine.AddHostObject("$scMediaItem", new MediaItem());
+                engine.AddHostType("$scFieldIDs", typeof(Sitecore.FieldIDs));
 
 				if (scripts != null && paths != null)
 				{
 					try
-					{
-						using (new Sitecore.Security.Accounts.UserSwitcher(Sitecore.Security.Accounts.User.FromName(RunAsUser, true)))
+					{						
+						using (new Sitecore.SecurityModel.SecurityDisabler())
 						{
-							using (new Sitecore.SecurityModel.SecurityDisabler())
+							foreach (string script in scripts)
 							{
-								foreach (string script in scripts)
-								{
-									pathIndex++;
+								pathIndex++;
 
-									engine.Execute(script);
-								}
+								engine.Execute(script);
+
+								pushContext.EndRunAsUser();
 							}
 						}
 

--- a/Sinj/PushHandler.cs
+++ b/Sinj/PushHandler.cs
@@ -70,7 +70,7 @@ namespace Sinj
 
 								engine.Execute(script);
 
-								pushContext.EndRunAsUser();
+								pushContext.RunAsUser(null);
 							}
 						}
 


### PR DESCRIPTION
This alters the approach taken in #1 - trying to stop changes to Base
Templates causing unhandled exceptions (Sitecore issue 470391).

Instead of wrapping all requests in a UserSwitcher, allow users to
specify when to switch to a user context in there scripts.

The UserSwitcher adds extra SQL calls to every request, which could
effect performance.

Adds methods/properties to the PushContext that will start and stop the
UserSwitcher. This can then be used in scripts to change the user Sinj
runs as. The user context will stop at the end of the script, unless
endRunAsUser is called first.

Updating the static helper scripts to spot base templates updates, and
throw an error giving details of the fix to the user.
